### PR TITLE
Explicitly set sudo for APT

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,3 +1,4 @@
 ---
 - name: Install unzip
+  sudo: yes
   apt: pkg=unzip={{ unzip_version }} state=present


### PR DESCRIPTION
This task currently assumes that sudo is already set to be able to install. Expliclity setting sudo on the tasks allows to keep sudo false on the rest of the Playbook.
